### PR TITLE
feat: add serviceaccount to staging/prod specs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # hokusai-integration-test
-Used by Hokusai project's integration tests.
+
+Hokusai project's integration tests [clone](https://github.com/artsy/hokusai/blob/main/test/integration/conftest.py#L12) this repo and run tests on its staging/production/review-app specs.
+

--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -1,4 +1,11 @@
 ---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ project_name }}
+  namespace: default
+
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -37,6 +44,8 @@ spec:
         imagePullPolicy: Always
         ports:
         - containerPort: 80
+      serviceAccountName: {{ project_name }}
+
 ---
 apiVersion: v1
 kind: Service

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -1,4 +1,11 @@
 ---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ project_name }}
+  namespace: default
+
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -37,6 +44,8 @@ spec:
         imagePullPolicy: Always
         ports:
         - containerPort: 80
+      serviceAccountName: {{ project_name }}
+
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
I will update Hokusai's integration test to check that review_app command copies service accounts. Therefore, we have to add service account to specs here.