### PR TITLE
feat: break serviceaccount spec into its own yaml

### DIFF
--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -1,11 +1,4 @@
 ---
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: {{ project_name }}
-  namespace: default
-
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -1,11 +1,4 @@
 ---
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: {{ project_name }}
-  namespace: default
-
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/serviceaccount.yml
+++ b/serviceaccount.yml
@@ -1,0 +1,17 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: default
+  namespace: default
+imagePullSecrets:
+- name: regcred
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: hokusai-integration-test
+  namespace: default
+imagePullSecrets:
+- name: regcred


### PR DESCRIPTION
This is to agree with Artsy's Hokusai projects who do not have ServiceAccount spec in their staging/production Yamls.